### PR TITLE
Service Bus Message creates a Kubernetes Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $RESOURCE_GROUP=""
 $LOCATION=""
 $SUBSCRIPTION="$(az account show --query id --output tsv)"
 $USER_ASSIGNED_IDENTITY_NAME="uai-keda-asb"
-$FEDERATED_IDENTITY_CREDENTIAL_NAME="kedaFedIdentity" 
+$FEDERATED_IDENTITY_CREDENTIAL_NAME="KedaServiceBusK8sSaFedCred"
 $SERVICE_ACCOUNT_NAMESPACE="bases-jet"
 $SERVICE_ACCOUNT_NAME="keda-service-account"
 $AKS_CLUSTER_NAME=""
@@ -235,3 +235,11 @@ Description | Link
  KEDA sample with AKS Workload Identity | [.NET Core worker processing Azure Service Bus Queue scaled by KEDA with Azure AD Workload Identity](https://github.com/kedacore/sample-dotnet-worker-servicebus-queue/blob/main/workload-identity.md)
  AKS Autoscaler profile | [Use the cluster autoscaler in Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler?tabs=azure-cli#use-the-cluster-autoscaler-profile)
  AKS Workload Identity with an app | [Use a workload identity with an application on Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/learn/tutorial-kubernetes-workload-identity)
+
+## Extras
+
+- To list all Federated Credentials attached to a Managed Identity:
+
+```powershell
+az identity federated-credential list -g $RESOURCE_GROUP --identity-name $USER_ASSIGNED_IDENTITY_NAME
+```

--- a/src/ListenerAPI/helm-chart/templates/configMap.yaml
+++ b/src/ListenerAPI/helm-chart/templates/configMap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   AzSbNsQueueName: {{ .Values.listener.serviceBus.namespace }}/{{ .Values.listener.serviceBus.queue }}
-  StartMessagesProcessor: "{{ .Values.listener.serviceBus.startMessageProcessor }}"
+  StartMessagesProcessor: "{{ .Values.listener.serviceBus.useMessageProcessor }}"
   JobsNamespace: "bases-jet"
   JobsPrefix: "azure-dev"
   JobsRepository: {{ .Values.repository }}

--- a/src/ListenerAPI/helm-chart/templates/deployment.yaml
+++ b/src/ListenerAPI/helm-chart/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: {{ include "listener.fullname" . }}-listener
         azure.workload.identity/use: "true"
     spec:
-      serviceAccountName: {{ .Values.listener.k8sServiceAccountName }}
+      serviceAccountName: {{ .Values.listener.listenerK8sServiceAccountName }}
       nodeSelector:
         "{{ .Values.listener.nodeSelector.key }}": {{ .Values.listener.nodeSelector.value }}
       containers:

--- a/src/ListenerAPI/helm-chart/templates/keda-scaledObject-serviceBus.yaml
+++ b/src/ListenerAPI/helm-chart/templates/keda-scaledObject-serviceBus.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.listener.serviceBus.useKedaAutoScaler }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
@@ -34,3 +35,4 @@ spec:
       cloud: AzurePublicCloud # Optional. Default: AzurePublicCloud
     authenticationRef:
         name: azure-servicebus-auth # authenticationRef would need either podIdentity or define a connection parameter
+{{ end }}

--- a/src/ListenerAPI/helm-chart/templates/keda-scaledObject-serviceBus.yaml
+++ b/src/ListenerAPI/helm-chart/templates/keda-scaledObject-serviceBus.yaml
@@ -34,5 +34,5 @@ spec:
       messageCount: "2" # default 5
       cloud: AzurePublicCloud # Optional. Default: AzurePublicCloud
     authenticationRef:
-        name: azure-servicebus-auth # authenticationRef would need either podIdentity or define a connection parameter
+        name: {{ .Values.listener.serviceBus.kedaTriggerAuthName }} # authenticationRef would need either podIdentity or define a connection parameter
 {{ end }}

--- a/src/ListenerAPI/helm-chart/templates/keda-serviceAccount.yaml
+++ b/src/ListenerAPI/helm-chart/templates/keda-serviceAccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.listener.serviceBus.kedaServiceAccountName }}
+  name: {{ .Values.listener.serviceBus.kedaK8sServiceAccountName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     azure.workload.identity/client-id: {{ .Values.listener.serviceBus.kedaUaiClientId }}

--- a/src/ListenerAPI/helm-chart/templates/keda-serviceAccount.yaml
+++ b/src/ListenerAPI/helm-chart/templates/keda-serviceAccount.yaml
@@ -1,7 +1,9 @@
+{{ if .Values.listener.serviceBus.useKedaAutoScaler }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: keda-service-account
+  name: {{ .Values.listener.serviceBus.kedaServiceAccountName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     azure.workload.identity/client-id: {{ .Values.listener.serviceBus.kedaUaiClientId }}
+{{ end }}

--- a/src/ListenerAPI/helm-chart/templates/keda-triggerAuthentication.yaml
+++ b/src/ListenerAPI/helm-chart/templates/keda-triggerAuthentication.yaml
@@ -2,7 +2,7 @@
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
-  name: azure-servicebus-auth
+  name: {{ .Values.listener.serviceBus.kedaTriggerAuthName }}
   namespace: {{ .Release.Namespace }}
 spec:
   podIdentity:

--- a/src/ListenerAPI/helm-chart/templates/keda-triggerAuthentication.yaml
+++ b/src/ListenerAPI/helm-chart/templates/keda-triggerAuthentication.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.listener.serviceBus.useKedaAutoScaler }}
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
@@ -7,3 +8,4 @@ spec:
   podIdentity:
     provider: azure-workload # azure | azure-workload
     identityId: {{ .Values.listener.serviceBus.kedaUaiClientId }}
+{{ end }}

--- a/src/ListenerAPI/helm-chart/templates/serviceAccount.yaml
+++ b/src/ListenerAPI/helm-chart/templates/serviceAccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.listener.k8sServiceAccountName }}
+  name: {{ .Values.listener.listenerK8sServiceAccountName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     azure.workload.identity/client-id: {{ .Values.listener.serviceBus.listenerUaiClientId }}

--- a/src/ListenerAPI/helm-chart/values.yaml
+++ b/src/ListenerAPI/helm-chart/values.yaml
@@ -13,7 +13,8 @@ repository:
 
 listener:
   replicaCount: 1
-  k8sServiceAccountName: listenerapi-sa
+  listenerK8sServiceAccountName: listenerapi-sa
+  # Requires Federation: az identity federated-credential create --name ListenerApiK8sSaFedCred --identity-name $USER_ASSIGNED_IDENTITY_NAME --resource-group $RESOURCE_GROUP --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:$SERVICE_ACCOUNT_NAMESPACE:<listenerK8sServiceAccountName> --audience api://AzureADTokenExchange
   image:
     name: bases-jet/listenerapi
     tag: dev
@@ -39,7 +40,8 @@ listener:
     useKedaAutoScaler: false
     kedaUaiClientId:
     kedaTriggerAuthName: azure-servicebus-trigauth
-    kedaServiceAccountName: keda-sa
+    kedaK8sServiceAccountName: keda-sa
+    # Requires Federation: az identity federated-credential create --name KedaServiceBusK8sSaFedCred --identity-name $USER_ASSIGNED_IDENTITY_NAME --resource-group $RESOURCE_GROUP --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:$SERVICE_ACCOUNT_NAMESPACE:<kedaK8sServiceAccountName> --audience api://AzureADTokenExchange
 
 jobs:
   image:

--- a/src/ListenerAPI/helm-chart/values.yaml
+++ b/src/ListenerAPI/helm-chart/values.yaml
@@ -32,6 +32,7 @@ listener:
   #   queue:
   #   startMessageProcessor:
   #   listenerUaiClientId:
+  #   startKedaAutoScaler:
   #   kedaUaiClientId:
 
 jobs:

--- a/src/ListenerAPI/helm-chart/values.yaml
+++ b/src/ListenerAPI/helm-chart/values.yaml
@@ -2,14 +2,18 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 # The values commented are set with non git checked-in value file. They are required.
+
 # Chart deployment is done with the following command:
 # `helm install listener ./helm-chart --namespace bases-jet --create-namespace --values ./helm-chart/values-secret.yaml`
 
-#  repository:
+# Chart upgrade is done with the following command:
+# `helm upgrade listener ./helm-chart --values ./helm-chart/values-secret.yaml`
+
+repository:
 
 listener:
   replicaCount: 1
-  k8sServiceAccountName: listener-service-account
+  k8sServiceAccountName: listenerapi-sa
   image:
     name: bases-jet/listenerapi
     tag: dev
@@ -23,17 +27,19 @@ listener:
     type: LoadBalancer
     port: 80
     targetPort: 8080
-  # azureFile:
-  #   storageAccountName:
-  #   storageAccountKey:
-  #   shareName:
-  # serviceBus:
-  #   namespace:
-  #   queue:
-  #   startMessageProcessor:
-  #   listenerUaiClientId:
-  #   startKedaAutoScaler:
-  #   kedaUaiClientId:
+  azureFile:
+    storageAccountName:
+    storageAccountKey:
+    shareName:
+  serviceBus:
+    namespace:
+    queue:
+    useMessageProcessor: false
+    listenerUaiClientId:
+    useKedaAutoScaler: false
+    kedaUaiClientId:
+    kedaTriggerAuthName: azure-servicebus-trigauth
+    kedaServiceAccountName: keda-sa
 
 jobs:
   image:


### PR DESCRIPTION
- This PR adds the code to create a Kubernetes Job when a new Service Bus message arrives at the queue.
- As the KEDA scaler was designed to scale the replicas count of the ListenerAPI deployment, a deploy switch was added, as it is not relevant anymore: the Messages are generating Kubernetes Jobs, then Completed, Abandoned or Dead-lettered, depending of the creation status.
- As Kubernetes Jobs must follow certain rules, a Job name creation and validation has been added.